### PR TITLE
fixed logging of the test runtime

### DIFF
--- a/tests/org.palladiosimulator.analyzer.slingshot.e2e.test/resources/log4j.properties
+++ b/tests/org.palladiosimulator.analyzer.slingshot.e2e.test/resources/log4j.properties
@@ -1,14 +1,2 @@
 # Root logger option
 log4j.rootLogger=ERROR, console
-
-# Define the console appender
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
-
-# (Optional) to fully suppress even WARN/INFO/DEBUG, set rootLogger to OFF
-# log4j.rootLogger=OFF, console
-
-# Example: Override the log level of a specific package/class if needed:
-# log4j.logger.org.palladiosimulator.analyzer.slingshot.e2e.helpers.TestModelURIs=ERROR
-# log4j.logger.org.palladiosimulator.analyzer.slingshot.core.InjectorHolder=ERROR

--- a/tests/org.palladiosimulator.analyzer.slingshot.e2e.test/resources/log4j.properties
+++ b/tests/org.palladiosimulator.analyzer.slingshot.e2e.test/resources/log4j.properties
@@ -1,0 +1,14 @@
+# Root logger option
+log4j.rootLogger=ERROR, console
+
+# Define the console appender
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+
+# (Optional) to fully suppress even WARN/INFO/DEBUG, set rootLogger to OFF
+# log4j.rootLogger=OFF, console
+
+# Example: Override the log level of a specific package/class if needed:
+# log4j.logger.org.palladiosimulator.analyzer.slingshot.e2e.helpers.TestModelURIs=ERROR
+# log4j.logger.org.palladiosimulator.analyzer.slingshot.core.InjectorHolder=ERROR

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -11,4 +11,18 @@
   <modules>
   	<module>org.palladiosimulator.analyzer.slingshot.e2e.test</module>
   </modules>
+
+ <build>
+    <plugins>
+        <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>tycho-surefire-plugin</artifactId>
+            <configuration>
+        	<!-- You can reference the file from your test resources directory -->
+        	<argLine>-Dlog4j.configuration=file:${project.basedir}/resources/log4j.properties</argLine>
+     		</configuration>
+        </plugin>
+    </plugins>
+</build>
+
 </project>


### PR DESCRIPTION
The change adds the log4j properties file to configure the logging level of the test runtime. 
A pointer to the file is passed through the tycho build configuration plugin and the corresponding arguments. 

Through the PR we only get a nice output about whether tests failed or nor, suitable for the pipeline. Still, devs could simply change the log level in case they want to see what is happening inside the simulator. 